### PR TITLE
FAI-2140 - Correction so that hours per week is decimal not long

### DIFF
--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Domain/WhenCastingApiResponseToAzureDocument.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Domain/WhenCastingApiResponseToAzureDocument.cs
@@ -24,7 +24,7 @@ public class WhenCastingApiResponseToAzureDocument
             apprenticeAzureSearchDocument.ApplicationInstructions.Should().Be(source.ApplicationInstructions);
             apprenticeAzureSearchDocument.AccountPublicHashedId.Should().Be(source.AccountPublicHashedId);
             apprenticeAzureSearchDocument.AccountLegalEntityPublicHashedId.Should().Be(source.AccountLegalEntityPublicHashedId);
-            apprenticeAzureSearchDocument.HoursPerWeek.Should().Be((long)source.Wage.WeeklyHours);
+            apprenticeAzureSearchDocument.HoursPerWeek.Should().Be(source.Wage.WeeklyHours);
             apprenticeAzureSearchDocument.ProviderName.Should().BeEquivalentTo(source.ProviderName);
             apprenticeAzureSearchDocument.StartDate.Should().Be(source.StartDate);
             apprenticeAzureSearchDocument.PostedDate.Should().Be(source.PostedDate);

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Domain/WhenCastingApiResponseToAzureDocument.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Domain/WhenCastingApiResponseToAzureDocument.cs
@@ -24,7 +24,7 @@ public class WhenCastingApiResponseToAzureDocument
             apprenticeAzureSearchDocument.ApplicationInstructions.Should().Be(source.ApplicationInstructions);
             apprenticeAzureSearchDocument.AccountPublicHashedId.Should().Be(source.AccountPublicHashedId);
             apprenticeAzureSearchDocument.AccountLegalEntityPublicHashedId.Should().Be(source.AccountLegalEntityPublicHashedId);
-            apprenticeAzureSearchDocument.HoursPerWeek.Should().Be(source.Wage.WeeklyHours);
+            apprenticeAzureSearchDocument.HoursPerWeek.Should().Be((double)source.Wage.WeeklyHours);
             apprenticeAzureSearchDocument.ProviderName.Should().BeEquivalentTo(source.ProviderName);
             apprenticeAzureSearchDocument.StartDate.Should().Be(source.StartDate);
             apprenticeAzureSearchDocument.PostedDate.Should().Be(source.PostedDate);

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Documents/ApprenticeAzureSearchDocument.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Documents/ApprenticeAzureSearchDocument.cs
@@ -23,7 +23,7 @@ public class ApprenticeAzureSearchDocument
             ApplicationInstructions = source.ApplicationInstructions,
             AccountPublicHashedId = source.AccountPublicHashedId,
             AccountLegalEntityPublicHashedId = source.AccountLegalEntityPublicHashedId,
-            HoursPerWeek = (long)source.Wage!.WeeklyHours,
+            HoursPerWeek = source.Wage!.WeeklyHours,
             ProviderName = source.ProviderName,
             StartDate = source.StartDate,
             PostedDate = source.PostedDate,
@@ -78,7 +78,7 @@ public class ApprenticeAzureSearchDocument
             ApplicationUrl = source.ApplicationUrl,
             AccountPublicHashedId = source.AccountPublicHashedId,
             AccountLegalEntityPublicHashedId = source.AccountLegalEntityPublicHashedId,
-            HoursPerWeek = (long)source.Wage!.WeeklyHours,
+            HoursPerWeek = source.Wage!.WeeklyHours,
             ProviderName = source.ProviderName,
             StartDate = source.StartDate,
             PostedDate = source.PostedDate,
@@ -145,7 +145,7 @@ public class ApprenticeAzureSearchDocument
     public string? ApplicationUrl { get; set; }
 
     [SimpleField]
-    public long HoursPerWeek { get; set; }
+    public decimal HoursPerWeek { get; set; }
 
     [SearchableField(IsFilterable = true, IsSortable = true, IsFacetable = true, NormalizerName = "lowercase")]
     public string? ProviderName { get; set; }

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Documents/ApprenticeAzureSearchDocument.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Documents/ApprenticeAzureSearchDocument.cs
@@ -23,7 +23,7 @@ public class ApprenticeAzureSearchDocument
             ApplicationInstructions = source.ApplicationInstructions,
             AccountPublicHashedId = source.AccountPublicHashedId,
             AccountLegalEntityPublicHashedId = source.AccountLegalEntityPublicHashedId,
-            HoursPerWeek = source.Wage!.WeeklyHours,
+            HoursPerWeek = (double)source.Wage!.WeeklyHours,
             ProviderName = source.ProviderName,
             StartDate = source.StartDate,
             PostedDate = source.PostedDate,
@@ -78,7 +78,7 @@ public class ApprenticeAzureSearchDocument
             ApplicationUrl = source.ApplicationUrl,
             AccountPublicHashedId = source.AccountPublicHashedId,
             AccountLegalEntityPublicHashedId = source.AccountLegalEntityPublicHashedId,
-            HoursPerWeek = source.Wage!.WeeklyHours,
+            HoursPerWeek = (double)source.Wage!.WeeklyHours,
             ProviderName = source.ProviderName,
             StartDate = source.StartDate,
             PostedDate = source.PostedDate,
@@ -145,7 +145,7 @@ public class ApprenticeAzureSearchDocument
     public string? ApplicationUrl { get; set; }
 
     [SimpleField]
-    public decimal HoursPerWeek { get; set; }
+    public double HoursPerWeek { get; set; }
 
     [SearchableField(IsFilterable = true, IsSortable = true, IsFacetable = true, NormalizerName = "lowercase")]
     public string? ProviderName { get; set; }


### PR DESCRIPTION
Currently `HoursPerWeek` is being indexed as a long which is causing values such as **37.5** to be set to **37**. This change fixes the storing of the data in the index