### PR TITLE
Tech debt email notifications property names consistent

### DIFF
--- a/src/SFA.DAS.FindApprenticeship.Jobs.AcceptanceTests/Infrastructure/TestDataValues.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.AcceptanceTests/Infrastructure/TestDataValues.cs
@@ -189,8 +189,8 @@ public class TestDataValues
                     Title = "Vacancy 1000",
                     ApprenticeshipTitle = "Apprenticeship title 1000",
                     Description = "<ul>\r\n<li>API Testing</li>\r\n<li>Selenium Training</li>\r\n<li>Automation Testing</li>\r\n</ul>",
-                    EmploymentLocationOption = AvailableWhere.MultipleLocations,
-                    EmploymentLocations = 
+                    EmployerLocationOption = AvailableWhere.MultipleLocations,
+                    EmployerLocations = 
                     [
                         new Address
                         {
@@ -237,8 +237,8 @@ public class TestDataValues
                     Title = "Vacancy 1001",
                     ApprenticeshipTitle = "Apprenticeship title 1001",
                     Description = "<ul>\r\n<li>API Testing</li>\r\n<li>Selenium Training</li>\r\n<li>Automation Testing</li>\r\n</ul>",
-                    EmploymentLocationOption = AvailableWhere.OneLocation,
-                    EmploymentLocations = 
+                    EmployerLocationOption = AvailableWhere.OneLocation,
+                    EmployerLocations = 
                     [
                         new Address
                         {
@@ -275,7 +275,7 @@ public class TestDataValues
                     Title = "Vacancy 1000",
                     ApprenticeshipTitle = "Apprenticeship title 1000",
                     Description = "<ul>\r\n<li>API Testing</li>\r\n<li>Selenium Training</li>\r\n<li>Automation Testing</li>\r\n</ul>",
-                    EmploymentLocationOption = AvailableWhere.AcrossEngland,
+                    EmployerLocationOption = AvailableWhere.AcrossEngland,
                     EmploymentLocationInformation = "Some information about the employment location",
                     EmployerName = "Dashkat Consulting Limited",
                     Ukprn = 10000528,

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/ApprenticeAzureSearchDocumentFactoryTests.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/ApprenticeAzureSearchDocumentFactoryTests.cs
@@ -11,8 +11,8 @@ public class ApprenticeAzureSearchDocumentFactoryTests
     public void Create_Maps_Deprecated_Address_Style_Vacancy(LiveVacancy liveVacancy)
     {
         // arrange
-        liveVacancy.EmploymentLocationOption = null;
-        liveVacancy.EmploymentLocations = null;
+        liveVacancy.EmployerLocationOption = null;
+        liveVacancy.EmployerLocations = null;
         liveVacancy.EmploymentLocationInformation = null;
 
         // act
@@ -33,9 +33,9 @@ public class ApprenticeAzureSearchDocumentFactoryTests
     public void Create_Maps_OneLocation_Vacancy(LiveVacancy liveVacancy)
     {
         // arrange
-        var address = liveVacancy.EmploymentLocations!.First();
-        liveVacancy.EmploymentLocationOption = AvailableWhere.OneLocation;
-        liveVacancy.EmploymentLocations = [address];
+        var address = liveVacancy.EmployerLocations!.First();
+        liveVacancy.EmployerLocationOption = AvailableWhere.OneLocation;
+        liveVacancy.EmployerLocations = [address];
         liveVacancy.EmploymentLocationInformation = null;
         liveVacancy.Address = null;
 
@@ -57,8 +57,8 @@ public class ApprenticeAzureSearchDocumentFactoryTests
     public void Create_Maps_RecruitNationally_Vacancy(LiveVacancy liveVacancy)
     {
         // arrange
-        liveVacancy.EmploymentLocationOption = AvailableWhere.AcrossEngland;
-        liveVacancy.EmploymentLocations = null;
+        liveVacancy.EmployerLocationOption = AvailableWhere.AcrossEngland;
+        liveVacancy.EmployerLocations = null;
         liveVacancy.Address = null;
 
         // act
@@ -80,7 +80,7 @@ public class ApprenticeAzureSearchDocumentFactoryTests
     public void Create_Maps_MultipleLocations_Vacancy(LiveVacancy liveVacancy)
     {
         // arrange
-        liveVacancy.EmploymentLocationOption = AvailableWhere.MultipleLocations;
+        liveVacancy.EmployerLocationOption = AvailableWhere.MultipleLocations;
         liveVacancy.Address = null;
         liveVacancy.EmploymentLocationInformation = null;
 
@@ -88,16 +88,16 @@ public class ApprenticeAzureSearchDocumentFactoryTests
         var documents = ApprenticeAzureSearchDocumentFactory.Create(liveVacancy).ToList();
 
         // assert
-        documents.Should().HaveCount(liveVacancy.EmploymentLocations!.Count);
+        documents.Should().HaveCount(liveVacancy.EmployerLocations!.Count);
         documents.Should().AllSatisfy(document =>
         {
             AssertDocumentIsMappedWithoutAddresses(document, liveVacancy);
-            liveVacancy.EmploymentLocations.Should().ContainEquivalentOf(document.Address);
+            liveVacancy.EmployerLocations.Should().ContainEquivalentOf(document.Address);
             document.AvailableWhere.Should().Be(nameof(AvailableWhere.MultipleLocations));
             document.EmploymentLocationInformation.Should().BeNull();
             document.Location.Should().BeEquivalentTo(new { document.Address!.Latitude, document.Address.Longitude });
             document.OtherAddresses.Should().NotBeNull();
-            document.OtherAddresses.Should().HaveCount(liveVacancy.EmploymentLocations!.Count - 1);
+            document.OtherAddresses.Should().HaveCount(liveVacancy.EmployerLocations!.Count - 1);
             document.OtherAddresses.Should().NotContainEquivalentOf(document.Address);
         });
         
@@ -109,7 +109,7 @@ public class ApprenticeAzureSearchDocumentFactoryTests
     public void Create_Maps_MultipleLocations_Vacancy_With_Unique_Ids(LiveVacancy liveVacancy)
     {
         // arrange
-        liveVacancy.EmploymentLocationOption = AvailableWhere.MultipleLocations;
+        liveVacancy.EmployerLocationOption = AvailableWhere.MultipleLocations;
         liveVacancy.Address = null;
         liveVacancy.EmploymentLocationInformation = null;
 
@@ -129,11 +129,11 @@ public class ApprenticeAzureSearchDocumentFactoryTests
         // arrange
         liveVacancy.IsEmployerAnonymous = true;
         liveVacancy.AnonymousEmployerName = "John Smith Ltd";
-        liveVacancy.EmploymentLocationOption = AvailableWhere.MultipleLocations;
+        liveVacancy.EmployerLocationOption = AvailableWhere.MultipleLocations;
         liveVacancy.Address = null;
         liveVacancy.EmploymentLocationInformation = null;
         
-        liveVacancy.EmploymentLocations = [
+        liveVacancy.EmployerLocations = [
             new Address { AddressLine3 = "London", Postcode = "SW1AA", Latitude = 1.2, Longitude = 2.3 },
             new Address { AddressLine3 = "London", Postcode = "SW1AA", Latitude = 1.2, Longitude = 2.3 },
             new Address { AddressLine3 = "London", Postcode = "SW2AA", Latitude = 1.2, Longitude = 2.3 },
@@ -148,7 +148,7 @@ public class ApprenticeAzureSearchDocumentFactoryTests
         documents.Should().AllSatisfy(document =>
         {
             AssertDocumentIsMappedWithoutAddresses(document, liveVacancy);
-            liveVacancy.EmploymentLocations.Should().ContainEquivalentOf(document.Address);
+            liveVacancy.EmployerLocations.Should().ContainEquivalentOf(document.Address);
             document.EmploymentLocationInformation.Should().BeNull();
             document.Location.Should().BeEquivalentTo(new { document.Address!.Latitude, document.Address.Longitude });
             document.OtherAddresses.Should().NotBeNull();

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingRecruitIndexerJob.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingRecruitIndexerJob.cs
@@ -16,14 +16,14 @@ namespace SFA.DAS.FindApprenticeship.Jobs.UnitTests.Application.Handlers
         public void Then_EmploymentLocationOption_Can_Be_Deserialized(string? value, AvailableWhere? expected)
         {
             // arrange
-            var json = $"{{\"EmploymentLocationOption\":{value}}}";
+            var json = $"{{\"EmployerLocationOption\":{value}}}";
             
             // act
             var newLiveVacancy = System.Text.Json.JsonSerializer.Deserialize<LiveVacancy>(json);
 
             // assert
             newLiveVacancy.Should().NotBeNull();
-            newLiveVacancy!.EmploymentLocationOption.Should().Be(expected);
+            newLiveVacancy!.EmployerLocationOption.Should().Be(expected);
         }
         
         [Test, MoqAutoData]

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingVacancyApprovedEvent.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingVacancyApprovedEvent.cs
@@ -74,7 +74,7 @@ public class WhenHandlingVacancyApprovedEvent
         [Frozen] Mock<IAzureSearchHelper> azureSearchHelper,
         VacancyApprovedHandler sut)
     {
-        liveVacancy.Value.EmploymentLocations = otherAddresses;
+        liveVacancy.Value.EmployerLocations = otherAddresses;
         liveVacancy.Value.StandardLarsCode = programmeId;
 
         var originalDocument = JsonSerializer.Deserialize<ApprenticeAzureSearchDocument>(JsonSerializer.Serialize(document.Value));

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingVacancyUpdatedEvent.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingVacancyUpdatedEvent.cs
@@ -27,7 +27,7 @@ public class WhenHandlingVacancyUpdatedEvent
         [Frozen] Mock<IAzureSearchHelper> azureSearchHelper,
         VacancyUpdatedHandler sut)
     {
-        liveVacancy.Value.EmploymentLocations = otherAddresses;
+        liveVacancy.Value.EmployerLocations = otherAddresses;
 
         findApprenticeshipJobsService.Setup(x => x.GetLiveVacancy(vacancyUpdatedEvent.VacancyReference.ToString())).ReturnsAsync(liveVacancy);
         azureSearchHelper.Setup(x => x.GetDocument(indexName, $"{vacancyUpdatedEvent.VacancyReference}")).ReturnsAsync(document);
@@ -75,7 +75,7 @@ public class WhenHandlingVacancyUpdatedEvent
         [Frozen] Mock<IAzureSearchHelper> azureSearchHelper,
         VacancyUpdatedHandler sut)
     {
-        liveVacancy.Value.EmploymentLocations = [];
+        liveVacancy.Value.EmployerLocations = [];
 
         findApprenticeshipJobsService.Setup(x => x.GetLiveVacancy(vacancyUpdatedEvent.VacancyReference.ToString())).ReturnsAsync(liveVacancy);
         azureSearchHelper.Setup(x => x.GetDocument(indexName, $"{vacancyUpdatedEvent.VacancyReference}")).ReturnsAsync(document);

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Application/ApprenticeAzureSearchDocumentFactory.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Application/ApprenticeAzureSearchDocumentFactory.cs
@@ -12,11 +12,11 @@ public static class ApprenticeAzureSearchDocumentFactory
     // as we now have a 1 to MANY relationship between live vacancies and azure indexed documents.
     public static IEnumerable<ApprenticeAzureSearchDocument> Create(LiveVacancy vacancy)
     {
-        switch (vacancy.EmploymentLocationOption)
+        switch (vacancy.EmployerLocationOption)
         {
             case AvailableWhere.OneLocation:
             {
-                var address = vacancy.EmploymentLocations![0];
+                var address = vacancy.EmployerLocations![0];
                 var document = MapWithoutAddress(vacancy);
                 document.Address = (AddressAzureSearchDocument)address;
                 document.IsPrimaryLocation = true;
@@ -26,7 +26,7 @@ public static class ApprenticeAzureSearchDocumentFactory
             case AvailableWhere.MultipleLocations:
             {
                 var results = new List<ApprenticeAzureSearchDocument>();
-                var locations = vacancy.EmploymentLocations!.DistinctBy(FlattenAddress).ToList();
+                var locations = vacancy.EmployerLocations!.DistinctBy(FlattenAddress).ToList();
                 var count = 0;
                 foreach (var address in locations)
                 {
@@ -72,7 +72,7 @@ public static class ApprenticeAzureSearchDocumentFactory
             ApplicationMethod = vacancy.ApplicationMethod,
             ApplicationUrl = vacancy.ApplicationUrl,
             ApprenticeshipLevel = vacancy.ApprenticeshipLevel,
-            AvailableWhere = vacancy.EmploymentLocationOption?.ToString()!,
+            AvailableWhere = vacancy.EmployerLocationOption?.ToString()!,
             ClosingDate = vacancy.ClosingDate,
             Course = (CourseAzureSearchDocument)vacancy,
             Description = vacancy.Description,

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Application/Handlers/VacancyUpdatedHandler.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Application/Handlers/VacancyUpdatedHandler.cs
@@ -29,10 +29,10 @@ public class VacancyUpdatedHandler(
         var updatedVacancy = await findApprenticeshipJobsService.GetLiveVacancy(vacancyUpdatedEvent.VacancyReference.ToString());
         vacancyReferenceIds.Add(updatedVacancy.Id);
         
-        if (updatedVacancy.EmploymentLocations is {Count: > 0})
+        if (updatedVacancy.EmployerLocations is {Count: > 0})
         {
             var counter = 1;
-            foreach (var azureSearchDocumentKey in updatedVacancy.EmploymentLocations.Select(_ => $"{updatedVacancy.Id}-{counter}"))
+            foreach (var azureSearchDocumentKey in updatedVacancy.EmployerLocations.Select(_ => $"{updatedVacancy.Id}-{counter}"))
             {
                 vacancyReferenceIds.Add(azureSearchDocumentKey);
                 counter++;

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Domain/SavedSearches/SavedSearchCandidateVacancies.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Domain/SavedSearches/SavedSearchCandidateVacancies.cs
@@ -43,9 +43,9 @@ namespace SFA.DAS.FindApprenticeship.Jobs.Domain.SavedSearches
             public string? EmployerName { get; set; }
 
             public Address? Address { get; set; }
-            public List<Address> OtherAddresses { get; set; } = [];
+            public List<Address>? OtherAddresses { get; set; } = [];
             public string? EmploymentLocationInformation { get; set; }
-            public string? EmploymentLocationOption { get; set; }
+            public string? EmployerLocationOption { get; set; }
 
             public string? Wage { get; set; }
 
@@ -74,7 +74,7 @@ namespace SFA.DAS.FindApprenticeship.Jobs.Domain.SavedSearches
                     Address = source.Address,
                     OtherAddresses = source.OtherAddresses.Count > 0 ? source.OtherAddresses.Select(x => (Address)x!).ToList() : [],
                     EmploymentLocationInformation = source.EmploymentLocationInformation,
-                    EmploymentLocationOption = source.EmploymentLocationOption,
+                    EmployerLocationOption = source.EmploymentLocationOption,
                     VacancySource = source.VacancySource,
                     WageUnit = source.WageUnit,
                     WageType = source.WageType

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/GetLiveVacanciesResponse.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/GetLiveVacanciesResponse.cs
@@ -20,9 +20,9 @@ public class LiveVacancy
     public string ApprenticeshipTitle { get; set; } = null!;
     public string? Description { get; set; }
     public Address? Address { get; set; }
-    public List<Address>? EmploymentLocations { get; set; }
+    public List<Address>? EmployerLocations { get; set; }
     [JsonConverter(typeof(JsonStringEnumConverter<AvailableWhere>))]
-    public AvailableWhere? EmploymentLocationOption { get; set; }
+    public AvailableWhere? EmployerLocationOption { get; set; }
     public string? EmploymentLocationInformation { get; set; }
     public string? EmployerName { get; set; }
     public string ApprenticeshipLevel { get; set; } = null!;


### PR DESCRIPTION
✨ Rename employment location properties to employer locations

- Changed `EmploymentLocationOption` to `EmployerLocationOption`.
- Updated `EmploymentLocations` to `EmployerLocations` across classes.
- Modified `TestDataValues` to use new property names for consistency.
- Adjusted tests in `ApprenticeAzureSearchDocumentFactoryTests`.
- Updated handling in `WhenHandlingVacancyApprovedEvent` and `WhenHandlingVacancyUpdatedEvent`.

Changes made by Balaji Jambulingam