### PR TITLE
FAI-2323 Search Alert Email Include Start Date

### DIFF
--- a/src/SFA.DAS.FindApprenticeship.Jobs/Domain/SavedSearches/SavedSearchCandidateVacancies.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Domain/SavedSearches/SavedSearchCandidateVacancies.cs
@@ -52,6 +52,7 @@ namespace SFA.DAS.FindApprenticeship.Jobs.Domain.SavedSearches
             public string? Wage { get; set; }
 
             public string? ClosingDate { get; set; }
+            public string? StartDate { get; set; }
 
             public string? TrainingCourse { get; set; }
 
@@ -71,6 +72,7 @@ namespace SFA.DAS.FindApprenticeship.Jobs.Domain.SavedSearches
                     EmployerName = source.EmployerName,
                     Wage = source.Wage,
                     ClosingDate = source.ClosingDate,
+                    StartDate = source.StartDate,
                     TrainingCourse = source.TrainingCourse,
                     Distance = source.Distance,
                     Address = source.Address,

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/GetCandidateSavedSearchResponse.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/GetCandidateSavedSearchResponse.cs
@@ -96,6 +96,9 @@ public class GetCandidateSavedSearchResponse
 
         [JsonPropertyName("closingDate")]
         public string? ClosingDate { get; set; }
+        
+        [JsonPropertyName("startDate")]
+        public string? StartDate { get; set; }
 
         [JsonPropertyName("trainingCourse")]
         public string? TrainingCourse { get; set; }


### PR DESCRIPTION
✨ Add StartDate property to SavedSearchCandidateVacancies

- Introduced `StartDate` property in `SavedSearchCandidateVacancies`.
- Updated object initialization to include `StartDate`.
- Added `StartDate` property to `GetCandidateSavedSearchResponse`.
- Included JSON serialization for `StartDate` with `[JsonPropertyName]`.
- Enhances saved search functionality with start date support.

Changes made by Balaji Jambulingam