### PR TITLE
FAI-2606 Access Civil Service Jobs API with a view to display in search results

### DIFF
--- a/src/SFA.DAS.FindApprenticeship.Jobs.AcceptanceTests/Infrastructure/TestDataValues.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.AcceptanceTests/Infrastructure/TestDataValues.cs
@@ -15,7 +15,7 @@ public class TestDataValues
         TotalLiveVacanciesReturned = PageSize,
         TotalLiveVacancies = 100,
         TotalPages = 100 / PageSize,
-        Vacancies = new List<LiveVacancy>()
+        Vacancies = new List<LiveVacancy>
             {
                 new()
                 {
@@ -305,7 +305,7 @@ public class TestDataValues
         TotalLiveVacanciesReturned = PageSize,
         TotalLiveVacancies = 100,
         TotalPages = 100 / PageSize,
-        Vacancies = new List<GetNhsLiveVacanciesApiResponse.NhsLiveVacancy>
+        Vacancies = new List<ExternalLiveVacancy>
             {
                 new()
                 {

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingVacancyClosingSoon.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingVacancyClosingSoon.cs
@@ -1,13 +1,8 @@
 using AutoFixture;
-using AutoFixture.NUnit3;
-using FluentAssertions;
 using FluentAssertions.Execution;
-using Moq;
-using NUnit.Framework;
 using SFA.DAS.FindApprenticeship.Jobs.Application.Handlers;
 using SFA.DAS.FindApprenticeship.Jobs.Domain.Interfaces;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Responses;
-using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FindApprenticeship.Jobs.UnitTests.Application.Handlers;
 
@@ -17,7 +12,7 @@ public class WhenHandlingVacancyClosingSoon
     public async Task Then_The_LiveVacancies_On_That_Closing_Day_Are_Retrieved(
         DateTime dateTime,
         List<LiveVacancy> liveVacancies,
-        List<GetNhsLiveVacanciesApiResponse.NhsLiveVacancy> nhsLiveVacancies,
+        List<ExternalLiveVacancy> nhsLiveVacancies,
         [Frozen] Mock<IDateTimeService> dateTimeService,
         [Frozen] Mock<IFindApprenticeshipJobsService> findApprenticeshipJobsService,
         VacancyClosingSoonHandler sut)

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingCivilServiceVacancies.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingCivilServiceVacancies.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions.Execution;
+using SFA.DAS.FindApprenticeship.Jobs.Application.Services;
+using SFA.DAS.FindApprenticeship.Jobs.Domain.Interfaces;
+using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Requests;
+using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Responses;
+
+namespace SFA.DAS.FindApprenticeship.Jobs.UnitTests.Application.Services.RecruitServiceTests;
+[TestFixture]
+public class WhenGettingCivilServiceVacancies
+{
+    [Test, MoqAutoData]
+    public async Task Then_The_Api_Is_Called_And_CivilService_Live_Vacancies_Returned(
+        int pageSize,
+        int pageNo,
+        ApiResponse<GetCivilServiceLiveVacanciesApiResponse> response,
+        [Frozen] Mock<IOuterApiClient> apiClient,
+        FindApprenticeshipJobsService service)
+    {
+        apiClient.Setup(x =>
+                x.Get<GetCivilServiceLiveVacanciesApiResponse>(
+                    It.Is<GetCivilServiceVacanciesApiRequest>(c => c.GetUrl.Contains("CivilServiceVacancies"))))
+            .ReturnsAsync(response);
+
+        var actual = await service.GetCivilServiceLiveVacancies();
+
+        using (new AssertionScope())
+        {
+            actual.Should().BeEquivalentTo(response.Body);
+        }
+    }
+}

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingLiveNhsVacancies.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingLiveNhsVacancies.cs
@@ -1,13 +1,8 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using FluentAssertions.Execution;
-using Moq;
-using NUnit.Framework;
+﻿using FluentAssertions.Execution;
 using SFA.DAS.FindApprenticeship.Jobs.Application.Services;
 using SFA.DAS.FindApprenticeship.Jobs.Domain.Interfaces;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Requests;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Responses;
-using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FindApprenticeship.Jobs.UnitTests.Application.Services.RecruitServiceTests
 {

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Infrastructure/Api/Requests/WhenBuildingGetCivilServiceVacanciesApiRequest.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Infrastructure/Api/Requests/WhenBuildingGetCivilServiceVacanciesApiRequest.cs
@@ -1,0 +1,13 @@
+﻿using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Requests;
+
+namespace SFA.DAS.FindApprenticeship.Jobs.UnitTests.Infrastructure.Api.Requests;
+[TestFixture]
+public class WhenBuildingGetCivilServiceVacanciesApiRequest
+{
+    [Test, MoqAutoData]
+    public void Then_The_GetUrl_Is_Built_Correctly()
+    {
+        var request = new GetCivilServiceVacanciesApiRequest();
+        request.GetUrl.Should().Be("CivilServiceVacancies");
+    }
+}

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Application/Services/FindApprenticeshipJobsService.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Application/Services/FindApprenticeshipJobsService.cs
@@ -29,6 +29,12 @@ public class FindApprenticeshipJobsService(IOuterApiClient apiClient) : IFindApp
         return liveVacancies.Body;
     }
 
+    public async Task<GetCivilServiceLiveVacanciesApiResponse?> GetCivilServiceLiveVacancies()
+    {
+        var liveVacancies = await apiClient.Get<GetCivilServiceLiveVacanciesApiResponse>(new GetCivilServiceVacanciesApiRequest());
+        return liveVacancies.Body;
+    }
+
     public async Task SendApplicationClosingSoonReminder(VacancyReference vacancyReference, int daysUntilExpiry)
     {
         await apiClient.Post<NullResponse>(new PostSendApplicationClosingSoonRequest(vacancyReference.Value, daysUntilExpiry));

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Documents/ApprenticeAzureSearchDocument.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Documents/ApprenticeAzureSearchDocument.cs
@@ -10,7 +10,7 @@ public class ApprenticeAzureSearchDocument
 {
     private const string VacancySourceNhs = "NHS";
     
-    public static implicit operator ApprenticeAzureSearchDocument(GetNhsLiveVacanciesApiResponse.NhsLiveVacancy source)
+    public static implicit operator ApprenticeAzureSearchDocument(ExternalLiveVacancy source)
     {
         return new ApprenticeAzureSearchDocument
         {
@@ -254,7 +254,7 @@ public class CourseAzureSearchDocument
         };
     }
 
-    public static implicit operator CourseAzureSearchDocument(GetNhsLiveVacanciesApiResponse.NhsLiveVacancy source)
+    public static implicit operator CourseAzureSearchDocument(ExternalLiveVacancy source)
     {
         return new CourseAzureSearchDocument
         {

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Interfaces/IFindApprenticeshipJobsService.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Domain/Interfaces/IFindApprenticeshipJobsService.cs
@@ -8,6 +8,7 @@ public interface IFindApprenticeshipJobsService
     Task<GetLiveVacanciesApiResponse?> GetLiveVacancies(int pageNumber, int pageSize, DateTime? closingDate = null);
     Task<GetLiveVacancyApiResponse> GetLiveVacancy(VacancyReference vacancyReference);
     Task<GetNhsLiveVacanciesApiResponse?> GetNhsLiveVacancies();
+    Task<GetCivilServiceLiveVacanciesApiResponse?> GetCivilServiceLiveVacancies();
     Task SendApplicationClosingSoonReminder(VacancyReference vacancyReference, int daysUntilExpiry);
     Task CloseVacancyEarly(VacancyReference vacancyReference);
     Task<GetCandidateSavedSearchesApiResponse> GetSavedSearches(int pageNumber, int pageSize, string lastRunDateTime, int maxApprenticeshipSearchResultCount = 5, string sortOrder = "AgeDesc");

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Requests/GetCivilServiceVacanciesApiRequest.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Requests/GetCivilServiceVacanciesApiRequest.cs
@@ -1,0 +1,7 @@
+﻿using SFA.DAS.FindApprenticeship.Jobs.Domain.Interfaces;
+
+namespace SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Requests;
+public record GetCivilServiceVacanciesApiRequest : IGetApiRequest
+{
+    public string GetUrl => "CivilServiceVacancies";
+}

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/ExternalLiveVacancy.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/ExternalLiveVacancy.cs
@@ -1,0 +1,57 @@
+﻿namespace SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Responses;
+public record ExternalLiveVacancy
+{
+    public Address Address { get; set; } = null!;
+    public bool IsDisabilityConfident { get; set; }
+    public bool IsEmployerAnonymous { get; set; }
+    public bool IsPositiveAboutDisability { get; set; }
+    public bool IsRecruitVacancy { get; set; }
+    public DateTime ClosingDate { get; set; }
+    public DateTime PostedDate { get; set; }
+    public DateTime StartDate { get; set; }
+    public Guid VacancyId { get; set; }
+    public IEnumerable<Qualification> Qualifications { get; set; } = null!;
+    public IEnumerable<string> Skills { get; set; } = null!;
+    public int Duration { get; set; }
+    public int Level { get; set; }
+    public int NumberOfPositions { get; set; }
+    public int RouteCode { get; set; }
+    public int? StandardLarsCode { get; set; }
+    public List<Address> OtherAddresses { get; set; } = [];
+    public long? Ukprn { get; set; }
+    public string ApplicationMethod { get; set; }
+    public string ApprenticeshipLevel { get; set; }
+    public string ApprenticeshipTitle { get; set; }
+    public string Id { get; set; }
+    public string LongDescription { get; set; }
+    public string OutcomeDescription { get; set; }
+    public string Route { get; set; }
+    public string Title { get; set; }
+    public string TrainingDescription { get; set; }
+    public string TypicalJobTitles { get; set; }
+    public string VacancyLocationType { get; set; }
+    public string VacancyReference { get; set; }
+    public string? AccountLegalEntityPublicHashedId { get; set; }
+    public string? AccountPublicHashedId { get; set; }
+    public string? AdditionalQuestion1 { get; set; }
+    public string? AdditionalQuestion2 { get; set; }
+    public string? AnonymousEmployerName { get; set; }
+    public string? ApplicationInstructions { get; set; }
+    public string? ApplicationUrl { get; set; }
+    public string? Description { get; set; }
+    public string? DurationUnit { get; set; }
+    public string? EmployerContactEmail { get; set; }
+    public string? EmployerContactName { get; set; }
+    public string? EmployerContactPhone { get; set; }
+    public string? EmployerDescription { get; set; }
+    public string? EmployerName { get; set; }
+    public string? EmployerWebsiteUrl { get; set; }
+    public string? OwnerType { get; set; }
+    public string? ProviderContactEmail { get; set; }
+    public string? ProviderContactName { get; set; }
+    public string? ProviderContactPhone { get; set; }
+    public string? ProviderName { get; set; }
+    public string? SearchTags { get; set; }
+    public string? ThingsToConsider { get; set; }
+    public Wage? Wage { get; set; }
+}

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/GetCivilServiceLiveVacanciesApiResponse.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Api/Responses/GetCivilServiceLiveVacanciesApiResponse.cs
@@ -1,5 +1,5 @@
 ﻿namespace SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Responses;
-public class GetNhsLiveVacanciesApiResponse
+public class GetCivilServiceLiveVacanciesApiResponse
 {
     public IEnumerable<ExternalLiveVacancy> Vacancies { get; set; } = null!;
     public int PageSize { get; set; }

--- a/src/SFA.DAS.FindApprenticeship.Jobs/local.settings.json
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/local.settings.json
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;",
     "AzureWebJobsServiceBus": "",
-    "NServiceBusConnectionString": "UseLearningEndpoint=true",
+    "NServiceBusConnectionString": "Endpoint=sb://das-demo-shared-ns.servicebus.windows.net/",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
     "ConfigNames": "SFA.DAS.FindApprenticeship.Jobs,SFA.DAS.Encoding",


### PR DESCRIPTION
✨ Refactor vacancy data model and add civil service support

- Updated `TestDataValues` to use `ExternalLiveVacancy` instead of NHS model.
- Modified `WhenHandlingRecruitIndexerJob` to handle civil service vacancies.
- Added `GetCivilServiceLiveVacancies` method in `FindApprenticeshipJobsService`.
- Introduced new classes and tests for civil service vacancy handling.
- Updated `local.settings.json` for service bus configuration changes.

Changes made by Balaji Jambulingam