### PR TITLE
FAI-3174 - Make sure failed vacancy call fails indexing

### DIFF
--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingRecruitIndexerJob.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Handlers/WhenHandlingRecruitIndexerJob.cs
@@ -93,6 +93,33 @@ public class WhenHandlingRecruitIndexerJob
             azureSearchHelper.Verify(x => x.UpdateAlias(Constants.AliasName, expectedIndexName), Times.Once);
         }
     }
+    
+    
+    [Test, MoqAutoData]
+    public void Then_If_Error_With_The_LiveVacancies_Index_Alias_Is_Not_Updated(
+        LiveVacancy vacancy,
+        List<LiveVacancy> liveVacancies,
+        List<NhsVacancy> nhsLiveVacancies,
+        List<CsjVacancy> civilServiceLiveVacancies,
+        [Frozen] Mock<IFindApprenticeshipJobsService> findApprenticeshipJobsService,
+        [Frozen] Mock<IAzureSearchHelper> azureSearchHelper,
+        [Frozen] Mock<IDateTimeService> dateTimeService,
+        DateTime currentDateTime,
+        RecruitIndexerJobHandler sut)
+    {
+        dateTimeService.Setup(x => x.GetCurrentDateTime()).Returns(currentDateTime);
+        var expectedIndexName = $"{Constants.IndexPrefix}{currentDateTime.ToString(Constants.IndexDateSuffixFormat)}";
+
+        findApprenticeshipJobsService.Setup(x => x.GetLiveVacancies(It.IsAny<int>(), 500, null)).ThrowsAsync(new Exception("Errors"));
+        
+        Assert.ThrowsAsync<Exception>(async() => await sut.Handle());
+
+        using (new AssertionScope())
+        {
+            azureSearchHelper.Verify(x => x.CreateIndex(expectedIndexName), Times.Once());
+            azureSearchHelper.Verify(x => x.UpdateAlias(Constants.AliasName, expectedIndexName), Times.Never);
+        }
+    }
 
     [Test, MoqAutoData]
     public async Task Then_LiveVacancies_Is_Null_And_Index_Is_Not_Created(

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingLiveVacancies.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingLiveVacancies.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.FindApprenticeship.Jobs.Application.Services;
 using SFA.DAS.FindApprenticeship.Jobs.Domain.Interfaces;
+using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Alerting;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Requests;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Responses;
 using SFA.DAS.Testing.AutoFixture;
@@ -16,24 +17,27 @@ public class WhenGettingLiveVacancies
     public async Task Then_The_Api_Is_Called_And_Live_Vacancies_Returned(
         int pageSize,
         int pageNo,
-        ApiResponse<GetLiveVacanciesApiResponse> response,
+        GetLiveVacanciesApiResponse response,
         [Frozen] Mock<IOuterApiClient> apiClient,
+        [Frozen] Mock<IIndexingAlertsManager> indexingAlertsManager,
         FindApprenticeshipJobsService service)
     {
-        response.Body.PageNo = pageNo;
-        response.Body.PageSize = pageSize;
+        response.PageNo = pageNo;
+        response.PageSize = pageSize;
+        
         apiClient.Setup(x =>
         x.Get<GetLiveVacanciesApiResponse>(
             It.Is<GetLiveVacanciesApiRequest>(c => c.GetUrl.Contains($"livevacancies?pageSize={pageSize}&pageNo={pageNo}"))))
-            .ReturnsAsync(response);
+            .ReturnsAsync(new ApiResponse<GetLiveVacanciesApiResponse>(response, HttpStatusCode.OK,""));
 
         var actual = await service.GetLiveVacancies(pageNo, pageSize);
 
         using (new AssertionScope())
         {
-            actual.Should().BeEquivalentTo(response.Body);
+            actual.Should().BeEquivalentTo(response);
             actual.PageSize.Should().Be(pageSize);
             actual.PageNo.Should().Be(pageNo);
+            indexingAlertsManager.Verify(x=>x.SendFaaImportAlertAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
     }
     [Test, MoqAutoData]
@@ -41,6 +45,7 @@ public class WhenGettingLiveVacancies
         int pageSize,
         int pageNo,
         [Frozen] Mock<IOuterApiClient> apiClient,
+        [Frozen] Mock<IIndexingAlertsManager> indexingAlertsManager,
         FindApprenticeshipJobsService service)
     {
         apiClient.Setup(x =>
@@ -48,7 +53,7 @@ public class WhenGettingLiveVacancies
                     It.Is<GetLiveVacanciesApiRequest>(c => c.GetUrl.Contains($"livevacancies?pageSize={pageSize}&pageNo={pageNo}"))))
             .ReturnsAsync(new ApiResponse<GetLiveVacanciesApiResponse>(null!, HttpStatusCode.InternalServerError, "response-error"));
 
-        Assert.ThrowsAsync<Exception>(async() => await service.GetLiveVacancies(pageNo, pageSize));
-
+        Assert.ThrowsAsync<HttpRequestException>(async() => await service.GetLiveVacancies(pageNo, pageSize));
+        indexingAlertsManager.Verify(x=>x.SendFaaImportAlertAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingLiveVacancies.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs.UnitTests/Application/Services/RecruitServiceTests/WhenGettingLiveVacancies.cs
@@ -36,4 +36,19 @@ public class WhenGettingLiveVacancies
             actual.PageNo.Should().Be(pageNo);
         }
     }
+    [Test, MoqAutoData]
+    public void Then_The_Api_Is_Called_And_If_Error_Exception_Is_Returned(
+        int pageSize,
+        int pageNo,
+        [Frozen] Mock<IOuterApiClient> apiClient,
+        FindApprenticeshipJobsService service)
+    {
+        apiClient.Setup(x =>
+                x.Get<GetLiveVacanciesApiResponse>(
+                    It.Is<GetLiveVacanciesApiRequest>(c => c.GetUrl.Contains($"livevacancies?pageSize={pageSize}&pageNo={pageNo}"))))
+            .ReturnsAsync(new ApiResponse<GetLiveVacanciesApiResponse>(null!, HttpStatusCode.InternalServerError, "response-error"));
+
+        Assert.ThrowsAsync<Exception>(async() => await service.GetLiveVacancies(pageNo, pageSize));
+
+    }
 }

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Application/Services/FindApprenticeshipJobsService.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Application/Services/FindApprenticeshipJobsService.cs
@@ -13,7 +13,11 @@ public class FindApprenticeshipJobsService(IOuterApiClient apiClient) : IFindApp
     public async Task<GetLiveVacanciesApiResponse> GetLiveVacancies(int pageNumber, int pageSize, DateTime? closingDate = null)
     {
         var liveVacancies = await apiClient.Get<GetLiveVacanciesApiResponse>(new GetLiveVacanciesApiRequest(pageNumber, pageSize, closingDate));
-        return liveVacancies.Body;
+        if (liveVacancies.StatusCode == HttpStatusCode.OK)
+        {
+            return liveVacancies.Body;    
+        }
+        throw new Exception($"Failed to get live vacancies: {liveVacancies.StatusCode} ex: {liveVacancies.ErrorContent}");
     }
 
     public async Task<GetLiveVacancyApiResponse> GetLiveVacancy(VacancyReference vacancyReference)

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Application/Services/FindApprenticeshipJobsService.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Application/Services/FindApprenticeshipJobsService.cs
@@ -4,11 +4,12 @@ using SFA.DAS.FindApprenticeship.Jobs.Domain.Candidate;
 using SFA.DAS.FindApprenticeship.Jobs.Domain.Interfaces;
 using SFA.DAS.FindApprenticeship.Jobs.Domain.SavedSearches;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure;
+using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Alerting;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Requests;
 using SFA.DAS.FindApprenticeship.Jobs.Infrastructure.Api.Responses;
 
 namespace SFA.DAS.FindApprenticeship.Jobs.Application.Services;
-public class FindApprenticeshipJobsService(IOuterApiClient apiClient) : IFindApprenticeshipJobsService
+public class FindApprenticeshipJobsService(IOuterApiClient apiClient, IIndexingAlertsManager indexingAlertsManager) : IFindApprenticeshipJobsService
 {
     public async Task<GetLiveVacanciesApiResponse> GetLiveVacancies(int pageNumber, int pageSize, DateTime? closingDate = null)
     {
@@ -17,7 +18,9 @@ public class FindApprenticeshipJobsService(IOuterApiClient apiClient) : IFindApp
         {
             return liveVacancies.Body;    
         }
-        throw new Exception($"Failed to get live vacancies: {liveVacancies.StatusCode} ex: {liveVacancies.ErrorContent}");
+
+        await indexingAlertsManager.SendFaaImportAlertAsync();
+        throw new HttpRequestException($"Failed to get live vacancies: {liveVacancies.StatusCode} ex: {liveVacancies.ErrorContent}");
     }
 
     public async Task<GetLiveVacancyApiResponse> GetLiveVacancy(VacancyReference vacancyReference)

--- a/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Alerting/IndexingAlertsManager.cs
+++ b/src/SFA.DAS.FindApprenticeship.Jobs/Infrastructure/Alerting/IndexingAlertsManager.cs
@@ -10,6 +10,7 @@ public interface IIndexingAlertsManager
     Task SendNhsApiAlertAsync(CancellationToken cancellationToken = default);
     Task SendNhsImportAlertAsync(CancellationToken cancellationToken = default);
     Task SendCsjImportAlertAsync(CancellationToken cancellationToken = default);
+    Task SendFaaImportAlertAsync(CancellationToken cancellationToken = default);
 }
 
 public class IndexingAlertsManager(
@@ -22,6 +23,7 @@ public class IndexingAlertsManager(
     private static string Now => DateTime.UtcNow.ToString("d/M/yyyy @ HH:mm:ss");
     private AlertMessage Alert(string message) => new(Origin, environment.EnvironmentName, message, Now);
 
+    private AlertMessage ProblemReturningFaaData => Alert("The FAA API returned an error");
     private AlertMessage IndexEmptyMessage => Alert("The index contains no documents");
     private AlertMessage NoNhsVacanciesImported => Alert("No NHS vacancies were imported");
     private AlertMessage NoNhsVacanciesReturned => Alert("The external NHS API returned no vacancies");
@@ -57,6 +59,11 @@ public class IndexingAlertsManager(
     public async Task SendCsjImportAlertAsync(CancellationToken cancellationToken = default)
     {
         await SendAlertAsync(NoCivilServiceVacanciesReturned, cancellationToken);
+    }
+    
+    public async Task SendFaaImportAlertAsync(CancellationToken cancellationToken = default)
+    {
+        await SendAlertAsync(ProblemReturningFaaData, cancellationToken);
     }
 
     private async Task SendAlertAsync(AlertMessage alertMessage, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Currently if a get live vacancies call fails, then instead of causing the indexing to fail, the exception is being silenced. If it fails now it will cause the index to fail